### PR TITLE
大佬，发现您的项目引入了org.springframework:spring-web@5.3.4组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.fc</groupId>
@@ -11,7 +9,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <spring.version>5.3.4</spring.version>
+        <spring.version>5.3.7</spring.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Vmware Spring Framework权限提升漏洞
缺陷组件：org.springframework:spring-web@5.3.4
漏洞编号：CVE-2021-22118
漏洞描述：Vmware Spring Framework是美国威睿（Vmware）公司的一套开源的Java、JavaEE应用程序框架。该框架可帮助开发人员构建高质量的应用。
Vmware Spring Framework存在权限提升漏洞，攻击者可利用该漏洞读取或修改已上传到WebFlux应用程序的文件，或使用多部分请求数据覆盖任意文件。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2021-44961
影响范围：[5.3.0, 5.3.7)
最小修复版本：5.3.7
缺陷组件引入路径：com.fc:Maven_Project@1.0-SNAPSHOT->org.springframework:spring-web@5.3.4
```
另外我运行这个项目时，IDE的安全插件提示还有2个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=peb760